### PR TITLE
Fix wrong parsing telnet execution result

### DIFF
--- a/detox/src/devices/android/EmulatorTelnet.js
+++ b/detox/src/devices/android/EmulatorTelnet.js
@@ -27,7 +27,7 @@ class EmulatorTelnet {
 
   async exec(command) {
     let res = await this.connection.exec(`${command}`);
-    res = res.split('\n')[0];
+    res = res.split('\n')[1];
     return res;
   }
 


### PR DESCRIPTION
### Issue
* Wrong parsing the execution result of telnet
* It closes https://github.com/wix/detox/issues/379

### Reason
* `this.connection.exec()` returns following structured string.
```
COMMAND
RESULT
RESPONSE
``` 
* In the case of `avd name`
```
avd name
Nexus_5X_API_25
OK
```
* The problem is that a current `exec()` in `EmulatorTelnet.js` returns a first string of parsing the result of `this.connection.exec()`. Thus, it returns **COMMAND** not to expected **RESULT**.
* Thus, it makes the error like it could not find emulator on the currently ADB attached devices.

### Solution
* I fix the `exec()` returns the second string(**RESULT**).